### PR TITLE
API作成_管理者_案件一覧画面(#TSK-304) 

### DIFF
--- a/server/repository/projects.ts
+++ b/server/repository/projects.ts
@@ -2,6 +2,11 @@ import type { Prisma, Projects } from '@prisma/client'
 import { prisma } from '~/prisma/prismaClient'
 
 export const projectsRepository = {
+  async findMany(): Promise<Projects[]> {
+    return prisma.projects.findMany({
+      orderBy: { createdAt: 'desc' }
+    })
+  },
   async findManyNot(entriesProjects?: string[]): Promise<Projects[]> {
     return prisma.projects.findMany({
       where: {

--- a/server/router/projectsRouter.ts
+++ b/server/router/projectsRouter.ts
@@ -4,7 +4,10 @@ import { projectsRepository } from '../repository/projects'
 import { z } from 'zod'
 
 export const projectsRouter = router({
-  list: userProcedure.input(z.array(z.string())).query(async ({ input }) => {
+  list: userProcedure.query(async () => {
+    return await projectsRepository.findMany()
+  }),
+  listNot: userProcedure.input(z.array(z.string())).query(async ({ input }) => {
     return await projectsRepository.findManyNot(input)
   })
 })

--- a/src/app/admin/projects/page.tsx
+++ b/src/app/admin/projects/page.tsx
@@ -1,6 +1,28 @@
 import { ProjectList } from '@/app/_component/ProjectList'
 import { RoleType } from '@/types'
+import { serverApi } from '~/lib/trpc/server-api'
+import { redirect } from 'next/navigation'
+import { AFTER_NOT_SIGNIN_PATH_ADMIN } from '@/const/config'
 
-export default function AdminProjects() {
-  return <ProjectList roleType={RoleType.ADMIN} />
+export default async function AdminProjects() {
+  const api = serverApi()
+
+  // ユーザー認証
+  const user = await api
+    .adminInfo()
+    .catch(() => redirect(AFTER_NOT_SIGNIN_PATH_ADMIN))
+  if (!user) redirect(AFTER_NOT_SIGNIN_PATH_ADMIN)
+
+  // エントリーしたプロジェクトのID取得
+  const projectIds =
+    (await api.entries.list(user.id))?.map((e) => e.projectId) ?? []
+
+  // エントリーしていないプロジェクトの取得
+  const yetEntryProjects = await api.projects.list(projectIds).catch(() => null)
+
+  if (!yetEntryProjects || yetEntryProjects.length === 0) {
+    return <p>データがありませんでした。</p>
+  }
+
+  return <ProjectList roleType={RoleType.ADMIN} projects={yetEntryProjects} />
 }

--- a/src/app/admin/projects/page.tsx
+++ b/src/app/admin/projects/page.tsx
@@ -13,16 +13,12 @@ export default async function AdminProjects() {
     .catch(() => redirect(AFTER_NOT_SIGNIN_PATH_ADMIN))
   if (!user) redirect(AFTER_NOT_SIGNIN_PATH_ADMIN)
 
-  // エントリーしたプロジェクトのID取得
-  const projectIds =
-    (await api.entries.list(user.id))?.map((e) => e.projectId) ?? []
+  // プロジェクトの取得
+  const projects = await api.projects.list().catch(() => null)
 
-  // エントリーしていないプロジェクトの取得
-  const yetEntryProjects = await api.projects.list(projectIds).catch(() => null)
-
-  if (!yetEntryProjects || yetEntryProjects.length === 0) {
+  if (!projects || projects.length === 0) {
     return <p>データがありませんでした。</p>
   }
 
-  return <ProjectList roleType={RoleType.ADMIN} projects={yetEntryProjects} />
+  return <ProjectList roleType={RoleType.ADMIN} projects={projects} />
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -10,12 +10,18 @@ export default async function Projects() {
   const user = await api.userInfo().catch(() => redirect('/'))
   if (!user) redirect('/')
 
+  // 管理者権限でのログインの場合はリダイレクト
+  const userData = await api.user.find(user.id)
+  if (userData?.role === RoleType.ADMIN) redirect('/')
+
   // エントリーしたプロジェクトのID取得
   const projectIds =
     (await api.entries.list(user.id))?.map((e) => e.projectId) ?? []
 
   // エントリーしていないプロジェクトの取得
-  const yetEntryProjects = await api.projects.list(projectIds).catch(() => null)
+  const yetEntryProjects = await api.projects
+    .listNot(projectIds)
+    .catch(() => null)
 
   if (!yetEntryProjects || yetEntryProjects.length === 0) {
     return <p>データがありませんでした。</p>

--- a/src/const/config.ts
+++ b/src/const/config.ts
@@ -29,6 +29,9 @@ export function isLoginedCheckUrl(url: string): boolean {
   // url.startsWith('/users')
 }
 
+export const AFTER_NOT_SIGNIN_PATH_ADMIN =
+  '/admin/signin' satisfies LinkProps['href']
+
 // ログイン済みチェックで失敗した際のリダイレクト先
 export const LOGINED_CHECK_FAILED_REDIRECT_URL: string = '/'
 


### PR DESCRIPTION
### 実装内容
- 管理者ログインであるか確認
- そうでない場合は管理者ログイン画面へ遷移
- 案件一覧を取得

### 前タスク修正
- ユーザー案件一覧画面では、管理者でないことを確認するロジックを追加
- 一部api名の踏襲
