### PR TITLE
API作成_管理者_案件編集画面(#TSK-309)

### DIFF
--- a/server/repository/projects.ts
+++ b/server/repository/projects.ts
@@ -21,5 +21,15 @@ export const projectsRepository = {
     return prisma.projects.findUnique({
       where: { id }
     })
+  },
+  async update({
+    data
+  }: {
+    data: Prisma.ProjectsUpdateInput
+  }): Promise<Projects> {
+    return prisma.projects.update({
+      where: { id: data.id as string },
+      data
+    })
   }
 }

--- a/server/router/projectsRouter.ts
+++ b/server/router/projectsRouter.ts
@@ -2,6 +2,7 @@ import { router } from '~/lib/trpc/trpc'
 import { userProcedure } from '../middleware'
 import { projectsRepository } from '../repository/projects'
 import { z } from 'zod'
+import { TRPCError } from '@trpc/server'
 
 export const projectsRouter = router({
   list: userProcedure.query(async () => {
@@ -12,5 +13,33 @@ export const projectsRouter = router({
   }),
   find: userProcedure.input(z.string()).query(async ({ input }) => {
     return await projectsRepository.findUnique(input)
-  })
+  }),
+  update: userProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        title: z.string(),
+        summary: z.string(),
+        skills: z.array(z.string()),
+        rate: z.coerce.number(),
+        deadlineAt: z.date()
+      })
+    )
+    .mutation(async ({ input }) => {
+      const { id, ...data } = input
+      const project = await projectsRepository.findUnique(input.id)
+      if (!project) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Project not found'
+        })
+      }
+
+      return await projectsRepository.update({
+        data: {
+          ...input,
+          skills: input.skills
+        }
+      })
+    })
 })

--- a/src/app/admin/projects/[projectId]/edit/page.tsx
+++ b/src/app/admin/projects/[projectId]/edit/page.tsx
@@ -1,14 +1,37 @@
 import { Title } from '@mantine/core'
 import { InputForm } from '@/app/admin/projects/_component/InputForm'
 import { PageType } from '@/types'
+import { redirect } from 'next/navigation'
+import { serverApi } from '~/lib/trpc/server-api'
+import { AFTER_NOT_SIGNIN_PATH_ADMIN } from '@/const/config'
 
-export default function EditProject() {
+export default async function EditProject({
+  params
+}: {
+  params: { projectId: string }
+}) {
+  const projectId = params.projectId
+  const api = serverApi()
+
+  // ユーザー認証
+  const user = await api
+    .adminInfo()
+    .catch(() => redirect(AFTER_NOT_SIGNIN_PATH_ADMIN))
+  if (!user) redirect(AFTER_NOT_SIGNIN_PATH_ADMIN)
+
+  // プロジェクトの取得
+  const project = await api.projects.find(projectId).catch(() => null)
+
   return (
     <>
       <Title order={2} ta="center" mb="lg">
         案件編集
       </Title>
-      <InputForm pageType={PageType.EDIT} />
+      {project ? (
+        <InputForm pageType={PageType.EDIT} project={project} />
+      ) : (
+        <p>案件を読み込めませんでした</p>
+      )}
     </>
   )
 }

--- a/src/app/admin/projects/[projectId]/page.tsx
+++ b/src/app/admin/projects/[projectId]/page.tsx
@@ -16,7 +16,7 @@ export default async function AdminProjectDetail({
   const user = await api
     .adminInfo()
     .catch(() => redirect(AFTER_NOT_SIGNIN_PATH_ADMIN))
-  // if (!user) redirect(AFTER_NOT_SIGNIN_PATH_ADMIN)
+  if (!user) redirect(AFTER_NOT_SIGNIN_PATH_ADMIN)
 
   // プロジェクトの取得
   const project = await api.projects.find(projectId).catch(() => null)
@@ -29,7 +29,7 @@ export default async function AdminProjectDetail({
       {project ? (
         <ProjectDetails project={project} />
       ) : (
-        <p>プロジェクトを取得できませんでした。</p>
+        <p>案件を取得できませんでした。</p>
       )}
     </>
   )

--- a/src/app/admin/projects/_component/InputForm.tsx
+++ b/src/app/admin/projects/_component/InputForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import React, { useTransition } from 'react'
 import { z } from 'zod'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -16,7 +16,11 @@ import {
   MultiSelect
 } from '@mantine/core'
 import Link from 'next/link'
-import type { PageTypeProps } from '@/types'
+import { useRouter } from 'next/navigation'
+import { PageType, type PageTypeProps } from '@/types'
+import type { Projects } from '@prisma/client'
+import { editProject } from '@/serverActions/edit'
+import { AFTER_ADMIN_SIGNUP_FOR_DB_REGISTER_PATH } from '@/const/config'
 
 const inputSchema = z.object({
   title: z.string().min(1),
@@ -32,16 +36,61 @@ const inputSchema = z.object({
 })
 type InputFormData = z.infer<typeof inputSchema>
 
-export function InputForm({ pageType }: PageTypeProps) {
+type Props = {
+  pageType: PageType
+  project?: Projects
+}
+
+export function InputForm({ pageType, project }: Props) {
+  const [isPending, startTransition] = useTransition()
+
+  const router = useRouter()
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors, isSubmitting }
   } = useForm<InputFormData>({
-    resolver: zodResolver(inputSchema)
+    resolver: zodResolver(inputSchema),
+    defaultValues: project
+      ? {
+          title: project.title,
+          summary: project.summary,
+          skills: project.skills.join(','),
+          deadline: new Date(project.deadlineAt),
+          rate: project.rate
+        }
+      : undefined
   })
 
-  const onInputSubmit = async (data: InputFormData) => {}
+  // スキルの初期値を設定
+  React.useEffect(() => {
+    if (project?.skills) {
+      setValue('skills', project.skills.join(','))
+    }
+  }, [project, setValue])
+
+  const onInputSubmit = async (data: InputFormData) => {
+    try {
+      if (pageType === PageType.EDIT && project) {
+        await editProject({
+          id: project.id,
+          title: data.title,
+          summary: data.summary,
+          skills: data.skills.split(','),
+          rate: data.rate,
+          deadlineAt: data.deadline
+        })
+        startTransition(() => {
+          // @ts-ignore
+          router.replace(`/admin/projects/${project.id}`)
+        })
+      }
+    } catch (error) {
+      console.log(error)
+      console.error('保存に失敗しました:', error)
+    }
+  }
 
   return (
     <>
@@ -96,10 +145,22 @@ export function InputForm({ pageType }: PageTypeProps) {
                 </Text>
               }
               placeholder="スキルを選択"
-              data={['Next', 'Supabase', 'Typescript', 'React', 'Node.js']}
+              data={[
+                'Next.js',
+                'Supabase',
+                'TypeScript',
+                'React',
+                'Node.js',
+                'Ruby',
+                'Python',
+                'AWS',
+                'Prisma'
+              ]}
               searchable
               clearable
               required
+              defaultValue={project?.skills}
+              onChange={(value) => setValue('skills', value.join(','))}
             />
             <DateInput
               valueFormat="YYYY/MM/DD"
@@ -110,8 +171,11 @@ export function InputForm({ pageType }: PageTypeProps) {
               }
               placeholder="募集締切日"
               required
+              defaultValue={
+                project?.deadlineAt ? new Date(project.deadlineAt) : undefined
+              }
+              onChange={(value) => setValue('deadline', value || new Date())}
             />
-
             <TextInput
               label={
                 <span
@@ -132,8 +196,8 @@ export function InputForm({ pageType }: PageTypeProps) {
               required={false}
             />
 
-            <Button type="submit" loading={isSubmitting} mt={30}>
-              {pageType === 'NEW' ? '登録' : '保存'}
+            <Button type="submit" loading={isSubmitting || isPending} mt={30}>
+              {pageType === PageType.NEW ? '登録' : '保存'}
             </Button>
           </Stack>
         </form>

--- a/src/app/admin/projects/_component/InputForm.tsx
+++ b/src/app/admin/projects/_component/InputForm.tsx
@@ -20,7 +20,6 @@ import { useRouter } from 'next/navigation'
 import { PageType, type PageTypeProps } from '@/types'
 import type { Projects } from '@prisma/client'
 import { editProject } from '@/serverActions/edit'
-import { AFTER_ADMIN_SIGNUP_FOR_DB_REGISTER_PATH } from '@/const/config'
 
 const inputSchema = z.object({
   title: z.string().min(1),

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -43,7 +43,7 @@ export default async function ProjectDetail({
       {project ? (
         <ProjectDetails project={project} userId={user.id} />
       ) : (
-        <p>プロジェクトを取得できませんでした。</p>
+        <p>案件を取得できませんでした。</p>
       )}
     </>
   )

--- a/src/serverActions/edit.ts
+++ b/src/serverActions/edit.ts
@@ -1,0 +1,17 @@
+'use server'
+
+import { serverApi } from '~/lib/trpc/server-api'
+
+type UpdateProjectInput = {
+  id: string
+  title: string
+  summary: string
+  skills: string[]
+  rate: number
+  deadlineAt: Date
+}
+
+export async function editProject(data: UpdateProjectInput) {
+  const api = serverApi()
+  return api.projects.update(data)
+}


### PR DESCRIPTION
### 実装内容
- 案件を取得（from Projects Table）
- 取得したものをフォームに反映
- フォームから編集したものをテーブルに更新（to Projects Table）
- 更新が完了したら案件詳細画面へリダイレクト

### 注意
- ts-ignore実装あり。要確認したいです。ページ遷移でこの方法が最適なのですが、型定義でエラーが出てしまう次第です。

